### PR TITLE
Avoid to send useless 0s when there are less than 8 bytes to send.

### DIFF
--- a/arduino code/libraries/HIDSerial/HIDSerial.cpp
+++ b/arduino code/libraries/HIDSerial/HIDSerial.cpp
@@ -162,7 +162,7 @@ size_t HIDSerial::write8(const uint8_t *buffer, size_t size)
   for(i=0;i<size && i<8; i++) {
     outBuffer[i] = buffer[i];
   }
-  usbSetInterrupt(outBuffer, 8);
+  usbSetInterrupt(outBuffer, i);
   return (i);
 }
 


### PR DESCRIPTION
It's better not to send useless 0s when we have not filled the buffer. In addition the function `Print::println` makes two separate calls to `write` the first to send the data and the second to send `\r\n`. So if we do like `serial.println('a');` it would send
`97 0 0 0 0 0 0 0`
`13 10 0 0 0 0 0 0`